### PR TITLE
Update to allow building under Windows

### DIFF
--- a/sample_unicode.py
+++ b/sample_unicode.py
@@ -27,8 +27,8 @@ db.measure = simstring.cosine
 db.threshold = 0.6
 
 # Use an 8-bit string encoded in UTF-8.
-print ' '.join(db.retrieve('スパゲティー'))
+print(' '.join(db.retrieve('スパゲティー')))
 
 # Convert a Unicode object into an UTF-8 query string.
-print ' '.join(db.retrieve(u'スパゲティー'.encode('utf-8')))
+print(' '.join(db.retrieve(u'スパゲティー'.encode('utf-8'))))
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_swigdir():
 
 from distutils.core import setup, Extension
 
-if sys.platform.startswith("darwin"):
+if sys.platform.startswith("darwin") or sys.platform.startswith("win") or sys.platform.startswith("cygwin"):
     libs = ['-liconv']
 else:
     # need iconv too but without proper -L adding -liconv here won't always work

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_swigdir():
 
 from distutils.core import setup, Extension
 
-if sys.platform.startswith("darwin") or sys.platform.startswith("win") or sys.platform.startswith("cygwin"):
+if sys.platform.startswith("darwin") or sys.platform.startswith("cygwin"):
     libs = ['-liconv']
 else:
     # need iconv too but without proper -L adding -liconv here won't always work


### PR DESCRIPTION
Ensuring that libiconv will be linked so that simstring can be built for Windows (under Cygwin or otherwise)