### PR TITLE
Fixing sample_unicode so that print() does not fail for Python 3.

### DIFF
--- a/sample_unicode.py
+++ b/sample_unicode.py
@@ -27,8 +27,8 @@ db.measure = simstring.cosine
 db.threshold = 0.6
 
 # Use an 8-bit string encoded in UTF-8.
-print ' '.join(db.retrieve('スパゲティー'))
+print(' '.join(db.retrieve('スパゲティー')))
 
 # Convert a Unicode object into an UTF-8 query string.
-print ' '.join(db.retrieve(u'スパゲティー'.encode('utf-8')))
+print(' '.join(db.retrieve(u'スパゲティー'.encode('utf-8'))))
 


### PR DESCRIPTION
Looks like this would work for Python 2 but will not work in Python 3.