### PR TITLE
Setting up build to occur seamlessly with Windows/Anaconda/VisualStudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # SimString Python Package
 
 Orginal version by [chokkan](), available [here](https://github.com/chokkan/simstring). New version (compiles under macOS) from [here](https://github.com/blinkhealth/simstring-python-package).
+
+Windows/Anaconda/VisualStudio specific steps:
+
+1. Make sure that iconv is available to your desired conda environment:
+  * conda install -c conda-forge libiconv
+2. Then, open a Visual Studio Developer Prompt (e.g. "VS 2015 x64 Developer Command Prompt" or "VS 2015 x86 Developer Command Prompt")
+3. Now you can any of these commands to build or install:
+  * python setup.py build
+  * python setup.py install
+4. NOTE: If there is a failure that 'rc.exe' cannot be found, add the appropriate WindowKits binary path to PATH.  More info on this here:
+  * https://stackoverflow.com/questions/14372706/visual-studio-cant-build-due-to-rc-exe

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,41 @@ def get_swigdir():
 
 from distutils.core import setup, Extension
 
+additional_include_dirs = []
+library_dirs = None
+extra_compile_args=None
+libs = []
 if sys.platform.startswith("darwin") or sys.platform.startswith("cygwin"):
     libs = ['-liconv']
+elif 'conda' in sys.version.lower() and sys.platform.startswith("win"):
+    # The conda/Windows-specific setup below assumes that the current conda environment has run something like this : 
+    # conda install -c conda-forge libiconv
+    print('Setting up assuming Anaconda was used to install iconv (conda install -c conda-forge libiconv)')
+    python_executable_dir = os.path.dirname(sys.executable)
+    anaconda_include_dir = os.path.join(python_executable_dir, 'Library/include')
+    anaconda_lib_dir = os.path.join(python_executable_dir, 'Library/lib')
+    use_conda_deps = True
+    
+    # let's check if these pieces are actually here before we try to give the include/lib hints below
+    if not os.path.isfile(os.path.join(anaconda_include_dir, 'iconv.h')):
+        print('Could not find header iconv.h at [{0}] so bypassing setup hints.  Verify that iconv was installed with conda.'.format(anaconda_include_dir))
+        use_conda_deps = False
+    elif not os.path.isfile(os.path.join(anaconda_lib_dir, 'iconv.lib')):
+        print('Could not find library iconv.lib at [{0}] so bypassing setup hints. Verify that iconv was installed with conda.'.format(anaconda_lib_dir))
+        use_conda_deps = False
+    
+    if use_conda_deps:
+        libs = ['iconv.lib']
+        additional_include_dirs = [anaconda_include_dir]
+        library_dirs = [anaconda_lib_dir]
+        # The = at the end of this with nothing after causes the symbol to have no associated value (instead of 'const') 
+        # so that this will compile under MSVC more info here:
+        # https://docs.microsoft.com/en-us/cpp/build/reference/d-preprocessor-definitions?view=vs-2017
+        extra_compile_args = ['/DICONV_CONST=']
+        print('Assuming Python executable [{0}], additional include dir [{1}], additional lib dir [{2}]'.format(python_executable_dir, anaconda_include_dir, anaconda_lib_dir))
+        print('Setting extra_compile_args to {0}'.format(extra_compile_args))
+        
+        print('NOTE: If there is a failure that rc.exe cannot be found, add the appropriate "WindowsKits" directory to the PATH for either x86 or x64.')
 else:
     # need iconv too but without proper -L adding -liconv here won't always work
     libs = []
@@ -32,8 +65,10 @@ simstring_module = Extension(
         'export.cpp',
         'export_wrap.cpp',
         ],
-    include_dirs=[get_includedir(),],
+    include_dirs=[get_includedir(),] + additional_include_dirs,
+    library_dirs=library_dirs,
     extra_link_args=libs,
+    extra_compile_args=extra_compile_args,
     language='c++',
     )
 


### PR DESCRIPTION
Once iconv is installed via Anaconda commands (included in comments and prompt) the include and libs are set up propery so that commands like 'python setup.py build' and 'python setup.py install' all work cleanly.  Added instructions for this to README.

I was doing this to simplify Windows building of this library and also the 'QuickUMLS' which uses this.  Using Anaconda was much simpler for me than Cygwin.  

If this PR is accepted, I'll update at least 1 StackOverflow answer with a much simpler solution following the README.md here.

Finally, I did test this change under Linux (my Raspberry PI Debian distro) and it built and ran the samples successfully.