### PR TITLE
Made compatible with macOS mojave

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,13 @@ else:
     # need iconv too but without proper -L adding -liconv here won't always work
     libs = []
 
+if sys.platform.startswith("darwin"):
+    # On recent macos versions (mojave) it is necessary to specify that libc++ is used instead of libstdc++.
+    # Furthermore, '-Wl,-undefined,dynamic_lookup' is necessary to link the right libraries.
+    libs += ["-stdlib=libc++", '-Wl,-undefined,dynamic_lookup']
+    extra_compile_args = ["-stdlib=libc++"]
+    
+    
 simstring_module = Extension(
     '_simstring',
     sources = [


### PR DESCRIPTION
After a 10hour-long fight I finally found how to make this work with macOS Mojave. Since apple deprecated stdlibc++, it is necessary to pass the extra argument "-stdlib=libc++" to both the compiler and the linker. Furthermore, as is the case in https://github.com/chokkan/crfsuite/issues/11, I modified the libraries given to the linker.